### PR TITLE
Added Travis CI configuration file, setup script, and build status icon.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: scala
+
+scala:
+  - 2.10.3
+
+jdk:
+  - oraclejdk7
+  - openjdk7
+
+before_script:
+  - sh src/test/resources/setup_travis.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #JASSH - SCALA SSH API#
 
+[![Build Status](https://travis-ci.org/dacr/jassh.png?branch=master)](https://travis-ci.org/dacr/jassh)
+
 High level scala SSH API for easy and fast operations on remote servers.
 
 This API is [JSCH](http://www.jcraft.com/jsch/) based. Interfaces are stable. Many helper functions are provided to simplify unix operations [ps, ls, cat, kill, find, ...](http://www.janalyse.fr/scaladocs/janalyse-ssh/#fr.janalyse.ssh.ShellOperations), an other goal of this API is to create an unix abstraction layer (Linux, Aix, Solaris, Darwin, ...).

--- a/src/test/resources/setup_travis.sh
+++ b/src/test/resources/setup_travis.sh
@@ -1,0 +1,24 @@
+#!/bin/sh 
+
+# Create test user
+sudo useradd -p `perl -e "print(crypt('testtest', 'AB'));"` test
+
+# Install ssh
+sudo apt-get update -qq
+sudo apt-get install -qq libssh2-1-dev openssh-client openssh-server
+
+# Generate and Register keys
+ssh-keygen -t rsa -f ~/.ssh/id_rsa -N "" -q
+cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
+sudo cp src/test/resources/sshconfig ~/.ssh/config
+sudo chmod 644 ~/.ssh/config
+
+sudo mkdir -p ~/../test/.ssh
+sudo cp ~/.ssh/id_rsa.pub  ~/../test/.ssh/authorized_keys
+sudo cp ~/.ssh/known_hosts ~/../test/.ssh/
+sudo chown -R test:test ~/../test
+sudo chmod 644 ~/../test/.ssh/*
+sudo chmod 755 ~/../test/.ssh
+
+sudo restart ssh

--- a/src/test/resources/sshconfig
+++ b/src/test/resources/sshconfig
@@ -1,0 +1,4 @@
+Host localhost
+  HostName localhost
+  IdentityFile ~/.ssh/id_rsa
+  User test


### PR DESCRIPTION
Using before_script, setup SSH and test user.

I have confirmed the almost all case success and two case failure at my repository.
https://travis-ci.org/zaneli/jassh/builds/24024449 [![Build Status](https://travis-ci.org/zaneli/jassh.png?branch=travis-ci)](https://travis-ci.org/zaneli/jassh)
- https://travis-ci.org/zaneli/jassh/jobs/24024450#L239
  I have confirmed `sh.test("1 == 1")` throw Exception, but `sh.test("1 = 1")` don't throw on Travis CI(Ubuntu).
  But on my local environment(CentOS) both `==` and `=` don't throw.
  I guess caused by the difference in installed ssh or OS distribution.
- https://travis-ci.org/zaneli/jassh/jobs/24024450#L188
  I'm sorry but I have no idea.
  (caused by the difference in version of openssh?
  Is my setup script bad?
  Or, is test code wrong?)

I hope the Travis CI environment and the test result make you resolve the problem.
