### PR TITLE
Depend on scalalogging instead of scalalogging-slf4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "janalyse-ssh"
 
-version := "0.9.16"
+version := "0.9.17-SNAPSHOT"
 
 organization :="fr.janalyse"
 
@@ -16,7 +16,7 @@ crossScalaVersions := Seq("2.10.5", "2.11.6")
 parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
-    "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"
    ,"com.jcraft"         % "jsch"               % "0.1.51"
    ,"org.apache.commons" % "commons-compress"   % "1.9"
    ,"org.scalatest"     %% "scalatest"          % "2.2.1"    % "test"

--- a/src/main/scala/fr/janalyse/ssh/PowerShellOperations.scala
+++ b/src/main/scala/fr/janalyse/ssh/PowerShellOperations.scala
@@ -16,7 +16,7 @@
 
 package fr.janalyse.ssh
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import java.text.SimpleDateFormat
 import java.util.Date
 import scala.collection.generic.CanBuildFrom

--- a/src/main/scala/fr/janalyse/ssh/SSHFtp.scala
+++ b/src/main/scala/fr/janalyse/ssh/SSHFtp.scala
@@ -4,7 +4,7 @@ import com.jcraft.jsch.{ChannelSftp, SftpException}
 import java.io._
 import java.nio.charset.Charset
 import scala.io.BufferedSource
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 
 
 class SSHFtp(implicit ssh: SSH) extends TransfertOperations with LazyLogging {

--- a/src/main/scala/fr/janalyse/ssh/ShellOperations.scala
+++ b/src/main/scala/fr/janalyse/ssh/ShellOperations.scala
@@ -16,7 +16,7 @@
 
 package fr.janalyse.ssh
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import java.text.SimpleDateFormat
 import java.util.Date
 import scala.collection.generic.CanBuildFrom


### PR DESCRIPTION
By depending on the facade instead of the slf4j implementation the implementation can be changed at runtime, and loss of binary compatibility is less likely.

Also, upgrade to a newer version of scalalogging.