### PR TITLE
Add support for SFTP rename

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "janalyse-ssh"
 
-version := "0.9.18"
+version := "0.9.19-SNAPSHOT"
 
 organization :="fr.janalyse"
 

--- a/src/main/scala/fr/janalyse/ssh/SSHFtp.scala
+++ b/src/main/scala/fr/janalyse/ssh/SSHFtp.scala
@@ -38,6 +38,15 @@ class SSHFtp(implicit ssh: SSH) extends TransfertOperations with SSHLazyLogging 
     }
   }
 
+  /**
+   * Rename a remote file or directory
+   * @param origin Original remote file name
+   * @param dest Destination (new) remote file name
+   */
+  def rename(origin: String, dest: String) = {
+    channel.rename(origin, dest)
+  }
+
   override def receive(remoteFilename: String, outputStream: OutputStream) {
     try {
       channel.get(remoteFilename, outputStream)


### PR DESCRIPTION
This exposes the rename function from the underlying JSCH SFTP channel instance to users of the jassh `SSHFtp` wrapper.

I considered sticking this in `TransfertOperations`, but that seems to be a unifying type between SFTP and SCP and I'm not certain that SCP supports server-side renames.