### PR TITLE
Add cd and rm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "janalyse-ssh"
 
-version := "0.9.18"
+version := "0.9.19-SNAPSHOT"
 
 organization :="fr.janalyse"
 

--- a/src/main/scala/fr/janalyse/ssh/SSHFtp.scala
+++ b/src/main/scala/fr/janalyse/ssh/SSHFtp.scala
@@ -38,6 +38,15 @@ class SSHFtp(implicit ssh: SSH) extends TransfertOperations with SSHLazyLogging 
     }
   }
 
+  /**
+   * Rename a remote file or directory
+   * @param origin Original remote file name
+   * @param dest Destination (new) remote file name
+   */
+  def rename(origin: String, dest: String) = {
+    channel.rename(origin, dest)
+  }
+
   override def receive(remoteFilename: String, outputStream: OutputStream) {
     try {
       channel.get(remoteFilename, outputStream)

--- a/src/main/scala/fr/janalyse/ssh/SSHFtp.scala
+++ b/src/main/scala/fr/janalyse/ssh/SSHFtp.scala
@@ -47,6 +47,24 @@ class SSHFtp(implicit ssh: SSH) extends TransfertOperations with SSHLazyLogging 
     channel.rename(origin, dest)
   }
 
+  /**
+   * Remove a file from a remote system
+   * @param path The path of the remote file to remove
+   */
+  def rm(path: String): Unit = channel.rm(path)
+
+  /**
+   * Remove a directory from a remote system
+   * @param path The path of the directory to remove
+   */
+  def rmdir(path: String): Unit = channel.rmdir(path)
+
+  /**
+   * Change the working directory on the remote system
+   * @param path The new working directory, relative to the current one
+   */
+  def cd(path: String): Unit = channel.cd(path)
+
   override def receive(remoteFilename: String, outputStream: OutputStream) {
     try {
       channel.get(remoteFilename, outputStream)


### PR DESCRIPTION
Add support for manipulating the working directory, and removing files and directories from the remote system to the SFTP wrapper.

Depends on #8

My apologies for the stream of pull requests - I'm working on a project that depends on this functionality and have been adding it as I encounter the need.