### PR TITLE
Add method to create a directory on remote SFTP.

### DIFF
--- a/src/main/scala/fr/janalyse/ssh/SSHFtp.scala
+++ b/src/main/scala/fr/janalyse/ssh/SSHFtp.scala
@@ -78,6 +78,12 @@ class SSHFtp(implicit ssh: SSH) extends TransfertOperations with SSHLazyLogging 
   def rmdir(path: String): Unit = channel.rmdir(path)
 
   /**
+   * Creates a directory on a remote system
+   * @param path The name of the directory to create
+   */
+  def mkdir(path: String): Unit = channel.mkdir(path)
+
+  /**
    * Change the working directory on the remote system
    * @param path The new working directory, relative to the current one
    */


### PR DESCRIPTION
Hello,

I was wondering if this API can be added to `SSHFtp` to allow the `mkdir` command when using sftp.

Cheers,
David