### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+sudo: true
 
 scala:
   - 2.10.6


### PR DESCRIPTION
`sudo: true` has to be set for the tests to run without errors (for the newly forked repos), since the TravisCI's default setting has been changed.